### PR TITLE
fix(android): restore ACTION_VIEW for shareBinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Revert Android `shareBinary` from `ACTION_SEND` back to `ACTION_VIEW` (regression introduced in 1.5.0): apps that open the file (such as document viewers/editors), not only apps that receive shared content, appear in the chooser again
+
 ## 1.6.0
 
 * Fix Swift Package Manager support: raise minimum Flutter to `>=3.44.0` and Dart SDK to `>=3.12.0`, matching the `FlutterFramework` Swift package that the SPM manifest depends on

--- a/android/src/main/kotlin/com/dr1009/app/share_binary/ShareBinaryPlugin.kt
+++ b/android/src/main/kotlin/com/dr1009/app/share_binary/ShareBinaryPlugin.kt
@@ -79,14 +79,12 @@ class ShareBinaryPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     /* authority = */ "${applicationContext.packageName}.share_binary.provider",
                     /* file = */ file,
                 )
-                val mimeType = applicationContext.contentResolver.getType(uri) ?: "*/*"
                 val intent = Intent.createChooser(
                     /* target = */
-                    Intent(Intent.ACTION_SEND).apply {
-                        type = mimeType
-                        putExtra(Intent.EXTRA_STREAM, uri)
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    },
+                    Intent(Intent.ACTION_VIEW)
+                        .setData(uri)
+                        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
                     /* title = */ chooserTitle,
                 )
                 activity.startActivity(intent)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_binary
 description: "This library provides the ability to use OS sharing features while handling binary files in dart code."
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/koji-1009/share_binary
 
 environment:


### PR DESCRIPTION
## What

Revert Android `shareBinary` from `ACTION_SEND` back to `ACTION_VIEW`, and release 1.6.1.

## Why

1.5.0 changed `shareBinary` from `ACTION_VIEW` to `ACTION_SEND` ("for broader app sharing support"). As a side effect, apps that only register an `ACTION_VIEW` intent-filter to **open** a file (document viewers/editors — e.g. `.doc`) stopped appearing in the chooser, because they do not declare a `SEND` receiver. Users updating from 1.4.0 to 1.6.0 reported that doc files could no longer be handed off to apps that open them.

`shareUri` was unaffected (it already uses `ACTION_VIEW`).

## Change

- `ShareBinaryPlugin.kt`: `shareBinary` intent `ACTION_SEND` → `ACTION_VIEW` (matches 1.4.0), and drop the now-unused `contentResolver.getType` MIME lookup.
- `pubspec.yaml`: `1.6.0` → `1.6.1`
- `CHANGELOG.md`: add 1.6.1 entry

Only the Android `shareBinary` intent behavior returns to 1.4.0; the rest of the 1.5.0/1.6.0 changes (iOS UIScene, AGP 9 / Kotlin, minSdk 24, etc.) are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)